### PR TITLE
Don't reallocate pcre2_match_data for every exec, you just need it once in comp

### DIFF
--- a/PCRE2.h
+++ b/PCRE2.h
@@ -61,4 +61,5 @@ const regexp_engine pcre2_engine = {
 
 struct re_engine_pcre2_data {
     pcre2_code *ri;
+    pcre2_match_data *match_data;
 };

--- a/PCRE2.h
+++ b/PCRE2.h
@@ -58,3 +58,7 @@ const regexp_engine pcre2_engine = {
     PCRE2_op_comp,
 #endif
 };
+
+struct re_engine_pcre2_data {
+    pcre2_code *ri;
+};


### PR DESCRIPTION
See the linked mailing list thread on the second patch. This presumably makes things faster, maybe my use of malloc/free here should be amended to use some xmalloc/perl malloc function.