### PR TITLE
Do not empty @ARGV in Makefile.PL

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -6,7 +6,7 @@ use Config;
 
 my $prefix;
 if (@ARGV) { # PREFIX=~
-  while (my $arg = shift @ARGV) {
+  for my $arg (@ARGV) {
     if ($arg =~ /^-?-?PREFIX=(.*)/i) {
       # lib and include prefix if installed locally (ie. travis)
       $prefix = $1;


### PR DESCRIPTION
Current code empties @ARGV before ExtUtils::MakeMaker can parse it.
Therefore any positional arguments to Makefile.PL intended for EU::MM
are ignored.

This patch fixes it.