### PR TITLE
BUG: broken variable expansion

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -22,6 +22,7 @@ t/split-null.t
 t/split.t
 t/subexp.t
 t/unimport.t
+t/variable_expansion.t
 t/z_kwalitee.t
 t/z_manifest.t
 t/z_pod-coverage.t

--- a/t/variable_expansion.t
+++ b/t/variable_expansion.t
@@ -1,0 +1,20 @@
+use strict;
+use warnings;
+
+use Test::More tests => 2;
+
+use re::engine::PCRE2;
+
+my $variable = 'll';
+
+# The following tests fail with newer-ish perls - anything that uses the op_comp implementation.
+
+# This pattern matches erroneously, because anything after (and including) ${variable} is thrown out
+ok("hello moon" !~ /^(he)${variable}o earth$/, "Variable expanded correctly, rest of the pattern not skipped!");
+
+# This pattern won't compile, because the regex engine only sees /H\w(/:
+# "Unmatched ( in regex; marked by <-- HERE in m/H\w( <-- HERE / at t/variable_expansion.t line 14."
+
+ok("Hello" =~ /H\w($variable)o/, "Variable expanded correctly, rest of the pattern not skipped!");
+
+

--- a/t/variable_expansion.t
+++ b/t/variable_expansion.t
@@ -7,14 +7,15 @@ use re::engine::PCRE2;
 
 my $variable = 'll';
 
-# The following tests fail with newer-ish perls - anything that uses the op_comp implementation.
+TODO: {
+    local $TODO = "Broken due to op_comp implementation - fix is work in progress";
+    # The following tests fail with newer-ish perls - anything that uses the op_comp implementation.
 
-# This pattern matches erroneously, because anything after (and including) ${variable} is thrown out
-ok("hello moon" !~ /^(he)${variable}o earth$/, "Variable expanded correctly, rest of the pattern not skipped!");
+    # This pattern matches erroneously, because anything after (and including) ${variable} is thrown out
+    ok("hello moon" !~ /^(he)${variable}o earth$/, "Variable expanded correctly, rest of the pattern not skipped!");
 
-# This pattern won't compile, because the regex engine only sees /H\w(/:
-# "Unmatched ( in regex; marked by <-- HERE in m/H\w( <-- HERE / at t/variable_expansion.t line 14."
+    # This pattern won't compile, because the regex engine only sees /H\w(/:
+    # "Unmatched ( in regex; marked by <-- HERE in m/H\w( <-- HERE / at t/variable_expansion.t line 14."
 
-ok("Hello" =~ /H\w($variable)o/, "Variable expanded correctly, rest of the pattern not skipped!");
-
-
+    ok(eval('"Hello" =~ /H\w($variable)o/'), "Variable expanded correctly, rest of the pattern not skipped!");
+};


### PR DESCRIPTION
Hi there!

Thanks for your module. I have noticed a bug: regular expressions using embedded variables (e.g. ``Hello" =~ /H\w($variable)o/``) won't work. Anything after $ is cut off.

This merge request contains a test case in`` t/variable_expansion.t``. I have traced this issue to your implementation of op_comp; once I remove that or use an older Perl (5.16), the test passes. However, that breaks other tests.