### PR TITLE
Fix compiler warnings

### DIFF
--- a/PCRE2.xs
+++ b/PCRE2.xs
@@ -707,7 +707,7 @@ CODE:
     char* table;
     regexp *re = RegSV(rx);
     pcre2_code *ri = (pcre2_code *)re->pprivate;
-    pcre2_pattern_info(ri, PCRE2_INFO_FIRSTBITMAP, table);
+    pcre2_pattern_info(ri, PCRE2_INFO_FIRSTBITMAP, &table);
     if (table) {
         ST(0) = sv_2mortal(newSVpvn(table, 256/8));
         XSRETURN(1);

--- a/PCRE2.xs
+++ b/PCRE2.xs
@@ -61,7 +61,6 @@ PCRE2_comp(pTHX_ SV * const pattern, U32 flags)
 
     STRLEN plen;
     char  *exp = SvPV((SV*)pattern, plen);
-    char *xend = exp + plen;
     U32 extflags = flags;
     SV * wrapped = newSVpvn_flags("(?", 2, SVs_TEMP);
     SV * wrapped_unset = newSVpvn_flags("", 0, SVs_TEMP);
@@ -71,7 +70,6 @@ PCRE2_comp(pTHX_ SV * const pattern, U32 flags)
     PCRE2_SIZE erroffset;
 
     /* pcre2_pattern_info */
-    PCRE2_SIZE length;
     U32 nparens;
 
     /* pcre_compile */
@@ -329,9 +327,10 @@ PCRE2_op_comp(pTHX_ SV ** const patternp, int pat_count,
             if (SvTYPE(sv) == SVt_REGEXP) {
                 bool is_ours = RX_ENGINE((REGEXP*)sv) == &pcre2_engine;
                 bool is_core = RX_ENGINE((REGEXP*)sv) == &PL_core_reg_engine;
-                const char *engine = is_core ? "core" : is_ours ? "pcre" : "plugin";
                 DEBUG_r(PerlIO_printf(Perl_debug_log,
-                                      "  %" SVf " <%s engine>\n", SVfARG(sv), engine));
+                                      "  %" SVf " <%s engine>\n", SVfARG(sv),
+                                      is_core ? "core" :
+                                      is_ours ? "pcre" : "plugin"));
                 if (!is_ours && !is_core) /* we can concat ours and core... */
                     can_concat = FALSE;
                 if (can_concat)
@@ -690,10 +689,8 @@ U32
 PCRE2_backrefmax(REGEXP *rx)
 
 U32
-PCRE2_bsr(REGEXP *rx, U32 value=0)
+PCRE2_bsr(REGEXP *rx)
 CODE:
-    if (items == 2)
-        croak("bsr setter nyi");
     RETVAL = PCRE2_bsr(rx);
     if (RETVAL == (U32)-1)
         XSRETURN_UNDEF;
@@ -728,6 +725,7 @@ PPCODE:
 #ifdef PCRE2_INFO_FRAMESIZE
     mXPUSHu(PCRE2_framesize(rx));
 #else
+    PERL_UNUSED_VAR(rx);
     XSRETURN_UNDEF;
 #endif
 
@@ -751,6 +749,8 @@ PPCODE:
         pcre2_set_heap_limit(match_context, (PCRE2_SIZE)value);
     mXPUSHu(PCRE2_heaplimit(rx));
 #else
+    PERL_UNUSED_VAR(rx);
+    PERL_UNUSED_VAR(value);
     XSRETURN_UNDEF;
 #endif
 
@@ -775,6 +775,7 @@ PCRE2_matchempty(REGEXP *rx)
 U32
 matchlimit(REGEXP *rx, U32 value=0)
 CODE:
+    PERL_UNUSED_VAR(value);
     if (items == 2)
         croak("matchlimit setter nyi");
     RETVAL = PCRE2_matchlimit(rx);


### PR DESCRIPTION
These two commits fixes warnings I can see with GCC 7.0.1, pcre2-10.23 and perl-5.24.1 on x86_64 platform.