### PR TITLE
Avoid a race in t/gh29-segv.t

### DIFF
--- a/t/gh29-segv.t
+++ b/t/gh29-segv.t
@@ -7,6 +7,9 @@ use re::engine::PCRE2;
 "Hello, world" =~ /(?<=Hello|Hi), (world)/;
 my $pid = fork;
 
-print "ok 1\n" if $pid;
-sleep 1;
-print "ok 2\n" unless $pid;
+if ($pid) {
+    print "not" if $pid != waitpid($pid, 0) or $?;
+    print "ok 2\n"
+} else {
+    print "ok 1\n";
+}


### PR DESCRIPTION
If the a parent process was too slow, a child process could print
"ok 2" before the parent printed "ok 1". That resulted into unordered
tests and was reported as an error.

This patch eliminites the race by synchronizing on the child
termination by calling waitpid(). Nevertheless it's necessary to
collect child's statuses to prevent from creating zombies.

https://github.com/rurban/re-engine-PCRE2/issues/34